### PR TITLE
Refactor Config system and add validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Start Changelog file for easy tracking.
+- Add validations for config.toml file (using pydantic)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update Readme to include Pypi release information.
-
+- Refactor usage of config from dictionary to class objects.
 
 ## [0.1.0.dev1]
 

--- a/bulkinvoicer/cli.py
+++ b/bulkinvoicer/cli.py
@@ -55,10 +55,10 @@ def main() -> None:
         bulkinvoicer_main(config_file)
     except Exception as e:
         if debug:
-            logger.exception(e)
+            logger.critical(e, exc_info=True)
         else:
-            logger.error("An error occurred while running Bulkinvoicer: %s", e)
-            logger.info("Run with --debug for more details.")
+            logger.critical("Bulkinvoicer encountered an error.")
+            logger.critical("Run with --debug for more details.")
         sys.exit(1)
 
     logger.info("Bulkinvoicer finished successfully.")

--- a/bulkinvoicer/config.py
+++ b/bulkinvoicer/config.py
@@ -180,7 +180,7 @@ class Config(BaseModel):
     payment: _PaymentConfig = _PaymentConfig()
     """Configuration for payment methods."""
 
-    footer: _FooterConfig
+    footer: _FooterConfig = _FooterConfig()
     """Configuration for the footer."""
 
     excel: _ExcelConfig

--- a/bulkinvoicer/config.py
+++ b/bulkinvoicer/config.py
@@ -28,7 +28,7 @@ class _InvoiceConfig(BaseModel):
     date_format: str = Field(default="%Y-%m-%d", alias="date-format")
     """Format for displaying dates in the invoice."""
 
-    tax_columns: list[str] | None = Field(default=None, alias="tax-columns")
+    tax_columns: list[str] = Field(default=[], alias="tax-columns")
     """List of tax columns to include in the invoice, if any."""
 
     discount_column: str | None = Field(default=None, alias="discount-column")

--- a/bulkinvoicer/config.py
+++ b/bulkinvoicer/config.py
@@ -2,7 +2,7 @@
 
 import datetime
 from typing import Literal
-from pydantic import BaseModel, ConfigDict, Field, FilePath
+from pydantic import BaseModel, ConfigDict, Field, FilePath, field_validator
 
 
 class _SellerConfig(BaseModel):
@@ -182,3 +182,11 @@ class Config(BaseModel):
 
     output: dict[str, _OutputConfig]
     """Configuration for output formats."""
+
+    @field_validator("output", mode="after")
+    @classmethod
+    def validate_output(cls, v: dict[str, _OutputConfig]) -> dict[str, _OutputConfig]:
+        """Ensure that the output configuration contains at least one entry."""
+        if not v:
+            raise ValueError("At least one output configuration must be provided.")
+        return v

--- a/bulkinvoicer/config.py
+++ b/bulkinvoicer/config.py
@@ -1,0 +1,184 @@
+"""Configuration for the bulkinvoicer application."""
+
+import datetime
+from typing import Literal
+from pydantic import BaseModel, ConfigDict, Field, FilePath
+
+
+class _SellerConfig(BaseModel):
+    """Configuration settings for the seller."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(min_length=1, max_length=50)
+    tagline: str | None = Field(default=None, max_length=100)
+
+
+class _InvoiceConfig(BaseModel):
+    """Configuration settings for invoices."""
+
+    model_config = ConfigDict(frozen=True)
+
+    decimals: int = Field(default=2, ge=0, le=6)
+    """Number of decimal places for invoice amounts."""
+
+    show_subtotal: bool = Field(default=True, alias="show-subtotal")
+    """Whether to show the subtotal in the invoice."""
+
+    date_format: str = Field(default="%Y-%m-%d", alias="date-format")
+    """Format for displaying dates in the invoice."""
+
+    tax_columns: list[str] | None = Field(default=None, alias="tax-columns")
+    """List of tax columns to include in the invoice, if any."""
+
+    discount_column: str | None = Field(default=None, alias="discount-column")
+    """Column name for discounts in the invoice, if applicable."""
+
+    style_color: str = Field(
+        default="#000000",
+        alias="style-color",
+        pattern=r"^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
+    )
+    """Color used for styling the invoice, in hex format."""
+
+
+class _ReceiptConfig(BaseModel):
+    """Configuration settings for receipts."""
+
+    model_config = ConfigDict(frozen=True)
+
+    decimals: int = Field(default=2, ge=0, le=6)
+    """Number of decimal places for receipt amounts."""
+
+    date_format: str = Field(default="%Y-%m-%d", alias="date-format")
+    """Format for displaying dates in the receipt."""
+
+    style_color: str = Field(
+        default="#000000",
+        alias="style-color",
+        pattern=r"^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
+    )
+    """Color used for styling the receipt, in hex format."""
+
+
+class _SignatureConfig(BaseModel):
+    """Configuration settings for signatures."""
+
+    model_config = ConfigDict(frozen=True)
+
+    prefix: str | None = Field(default=None, max_length=50)
+    """Prefix for the signature, if any."""
+
+    text: str | None = Field(default=None, max_length=50)
+    """Text for the signature, if any."""
+
+
+class _UPIConfig(BaseModel):
+    """Configuration settings for UPI payments."""
+
+    model_config = ConfigDict(frozen=True)
+
+    upi_id: str = Field(
+        alias="upi-id", pattern=r"^[a-zA-Z0-9.\-_]{2,256}@[a-zA-Z]{2,64}$"
+    )
+    """UPI ID for receiving payments."""
+
+    include_amount: bool = Field(default=True, alias="include-amount")
+    """Whether to include the amount in the UPI payment request."""
+
+    include_link: bool = Field(default=False, alias="include-link")
+    """Whether to include a payment link in the QR code image."""
+
+    transaction_note: str = Field(default="", max_length=50, alias="transaction-note")
+    """Transaction note for the UPI payment request."""
+
+    bottom_note: str | None = Field(default=None, max_length=50, alias="bottom-note")
+    """Note to display at the bottom of the UPI QR code image, if any."""
+
+
+class _PaymentConfig(BaseModel):
+    """Configuration settings for payment methods."""
+
+    model_config = ConfigDict(frozen=True)
+
+    upi: _UPIConfig | None = Field(default=None)
+    """Configuration for UPI payments, if applicable."""
+
+    currency: Literal["INR", "USD"] | str = Field(
+        default="INR",
+        alias="currency",
+        min_length=1,
+    )
+    """Currency for the payment methods, default is INR."""
+
+    payment_methods_text: str | None = Field(
+        default=None,
+        alias="payment-methods-text",
+        max_length=50,
+    )
+
+
+class _FooterConfig(BaseModel):
+    """Configuration settings for the footer."""
+
+    model_config = ConfigDict(frozen=True)
+
+    text: str
+    """Text to display in the footer, if any."""
+
+
+class _ExcelConfig(BaseModel):
+    """Configuration settings for Excel export."""
+
+    model_config = ConfigDict(frozen=True)
+
+    filepath: FilePath
+
+
+class _OutputConfig(BaseModel):
+    """Configuration settings for output formats."""
+
+    model_config = ConfigDict(frozen=True)
+
+    path: str
+    """Path to save the output files."""
+
+    type: Literal["combined", "clients", "individual"]
+
+    include_summary: bool = Field(default=False, alias="include-summary")
+
+    start_date: datetime.date | None = Field(default=None, alias="start-date")
+    """Start date for filtering invoices or receipts."""
+
+    end_date: datetime.date | None = Field(default=None, alias="end-date")
+    """End date for filtering invoices or receipts."""
+
+
+class Config(BaseModel):
+    """Configuration settings for the bulkinvoicer application."""
+
+    model_config = ConfigDict(frozen=True)
+
+    seller: _SellerConfig
+    """Configuration for the seller."""
+
+    invoice: _InvoiceConfig = _InvoiceConfig()
+    """Configuration for invoices."""
+
+    receipt: _ReceiptConfig = _ReceiptConfig()
+    """Configuration for receipts."""
+
+    signature: _SignatureConfig = _SignatureConfig()
+    """Configuration for signatures."""
+
+    payment: _PaymentConfig = _PaymentConfig()
+    """Configuration for payment methods."""
+
+    footer: _FooterConfig
+    """Configuration for the footer."""
+
+    excel: _ExcelConfig
+    """Configuration for Excel export."""
+
+    output: dict[str, _OutputConfig]
+    """Configuration for output formats."""

--- a/bulkinvoicer/config.py
+++ b/bulkinvoicer/config.py
@@ -83,6 +83,9 @@ class _UPIConfig(BaseModel):
     )
     """UPI ID for receiving payments."""
 
+    payee_name: str | None = Field(default=None, max_length=50, alias="payee-name")
+    """Name of the payee for UPI payments."""
+
     include_amount: bool = Field(default=True, alias="include-amount")
     """Whether to include the amount in the UPI payment request."""
 
@@ -123,7 +126,10 @@ class _FooterConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    text: str
+    text: str | None = Field(
+        default=None,
+        alias="text",
+    )
     """Text to display in the footer, if any."""
 
 
@@ -168,7 +174,7 @@ class Config(BaseModel):
     receipt: _ReceiptConfig = _ReceiptConfig()
     """Configuration for receipts."""
 
-    signature: _SignatureConfig = _SignatureConfig()
+    signature: _SignatureConfig | None = None
     """Configuration for signatures."""
 
     payment: _PaymentConfig = _PaymentConfig()

--- a/bulkinvoicer/config.py
+++ b/bulkinvoicer/config.py
@@ -35,7 +35,7 @@ class _InvoiceConfig(BaseModel):
     """Column name for discounts in the invoice, if applicable."""
 
     style_color: str = Field(
-        default="#000000",
+        default="#FFFFFF",
         alias="style-color",
         pattern=r"^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
     )
@@ -54,7 +54,7 @@ class _ReceiptConfig(BaseModel):
     """Format for displaying dates in the receipt."""
 
     style_color: str = Field(
-        default="#000000",
+        default="#FFFFFF",
         alias="style-color",
         pattern=r"^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
     )

--- a/bulkinvoicer/driver.py
+++ b/bulkinvoicer/driver.py
@@ -822,9 +822,7 @@ def generate(config: Config) -> None:
                     )
 
                     pdf = PDF(
-                        config=config.model_dump(
-                            mode="json", by_alias=True, exclude_unset=True
-                        ),
+                        config=config,
                         cover_page=include_summary,
                     )
                     pdf.set_title(key)
@@ -873,9 +871,7 @@ def generate(config: Config) -> None:
                         logger.info("Generating summary PDF")
 
                         pdf = PDF(
-                            config=config.model_dump(
-                                mode="json", by_alias=True, exclude_unset=True
-                            ),
+                            config=config,
                             cover_page=True,
                         )
                         pdf.set_title(f"{key} Overall Summary")
@@ -893,11 +889,7 @@ def generate(config: Config) -> None:
                         leave=False,
                         desc="Generating Invoices",
                     ):
-                        pdf = PDF(
-                            config=config.model_dump(
-                                mode="json", by_alias=True, exclude_unset=True
-                            )
-                        )
+                        pdf = PDF(config=config)
                         pdf.set_title(f"{key} Invoice {invoice_data['number']}")
                         generate_invoice(
                             pdf,
@@ -915,11 +907,7 @@ def generate(config: Config) -> None:
                         leave=False,
                         desc="Generating Receipts",
                     ):
-                        pdf = PDF(
-                            config=config.model_dump(
-                                mode="json", by_alias=True, exclude_unset=True
-                            )
-                        )
+                        pdf = PDF(config=config)
                         pdf.set_title(f"{key} Receipt {receipt_data['number']}")
                         generate_receipt(
                             pdf,
@@ -937,9 +925,7 @@ def generate(config: Config) -> None:
                         logger.info("Generating summary PDF")
 
                         pdf = PDF(
-                            config=config.model_dump(
-                                mode="json", by_alias=True, exclude_unset=True
-                            ),
+                            config=config,
                             cover_page=True,
                         )
                         pdf.set_title(f"{key} Overall Summary")
@@ -963,9 +949,7 @@ def generate(config: Config) -> None:
                             )
 
                             pdf = PDF(
-                                config=config.model_dump(
-                                    by_alias=True, exclude_unset=True
-                                ),
+                                config=config,
                                 cover_page=include_summary,
                             )
                             pdf.set_title(f"{key} {client_id}")

--- a/bulkinvoicer/driver.py
+++ b/bulkinvoicer/driver.py
@@ -187,7 +187,7 @@ def generate_invoice(
 
 def generate_receipt(
     pdf: PDF,
-    config: Mapping[str, Any],
+    config: Config,
     receipt_data: Mapping[str, Any],
     start_section: bool = False,
     create_toc_entry: bool = False,
@@ -195,7 +195,7 @@ def generate_receipt(
     """Generate a receipt PDF using the provided configuration."""
     logger.info("Generating receipt with the provided configuration.")
 
-    currency = config.get("payment", {}).get("currency", "INR")
+    currency = config.payment.currency
 
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug(f"Receipt data: {receipt_data}")
@@ -219,7 +219,8 @@ def generate_receipt(
     pdf.print_receipt_header(receipt_data)
 
     headings_style = FontFace(
-        emphasis="BOLD", fill_color=config.get("receipt", {}).get("style-color")
+        emphasis="BOLD",
+        fill_color=config.receipt.style_color,  # type: ignore[arg-type]
     )
 
     pdf.set_font(pdf.regular_font.family, size=10)
@@ -857,9 +858,7 @@ def generate(config: Config) -> None:
                     ):
                         generate_receipt(
                             pdf,
-                            config.model_dump(
-                                mode="json", by_alias=True, exclude_unset=True
-                            ),
+                            config,
                             receipt_data,
                             start_section=i == 0,
                             create_toc_entry=True,
@@ -924,9 +923,7 @@ def generate(config: Config) -> None:
                         pdf.set_title(f"{key} Receipt {receipt_data['number']}")
                         generate_receipt(
                             pdf,
-                            config.model_dump(
-                                mode="json", by_alias=True, exclude_unset=True
-                            ),
+                            config,
                             receipt_data,
                             start_section=False,
                             create_toc_entry=False,
@@ -1114,9 +1111,7 @@ def generate(config: Config) -> None:
                             ):
                                 generate_receipt(
                                     pdf,
-                                    config.model_dump(
-                                        mode="json", by_alias=True, exclude_unset=True
-                                    ),
+                                    config,
                                     receipt_data,
                                     start_section=i == 0,
                                     create_toc_entry=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "fpdf2 >= 2.8.3, < 3.0.0",
     "uharfbuzz",
     "tqdm >= 4.67.1, < 5.0.0",
+    "pydantic >= 2.11.7, < 3.0.0",
 ]
 requires-python = ">=3.10"
 authors = [


### PR DESCRIPTION
This pull request completely refactors the config management system away from unsafe dictionary-based config objects to much safer pydantic models.

It also adds validations and sensible defaults for all relevant configs, making it clear which config properties are required and which are optional.

At the bare minimum, the following fields are mandatory:
- `seller.name` - The seller name (and the file header)
- `excel.filepath` - The excel file path (source)
- `output.*` - At least 1 output format with the following fields:
  - `output.*.path` - Path of the output PDF
  - `output.*.type` - Type of the output

This can be boiled down to a minimum TOML file as follows:

```toml
[seller]
name = "John Doe"

[excel]
filepath = "invoices.xlsx"

[output.test]
path = "output/test.pdf"
type = "combined"
```