### PR TITLE
Add release automation

### DIFF
--- a/.github/scripts/get_release_notes.py
+++ b/.github/scripts/get_release_notes.py
@@ -1,0 +1,43 @@
+"""Get release notes from the CHANGELOG.md file."""
+
+import sys
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def main(*args) -> int:
+    """Main function to get release notes."""
+    changelog_file_path = "CHANGELOG.md"
+    version_no = None
+
+    if len(args) > 1:
+        for arg in args[1:]:
+            if arg.endswith(".md"):
+                changelog_file_path = arg
+            elif arg.startswith("v"):
+                version_no = arg[1:]
+                break
+
+    if not version_no:
+        raise ValueError("Version number must be specified in the format 'v<version>'")
+
+    with open(changelog_file_path) as file:
+        data = file.read()
+        start = data.index(f"## [{version_no}]") + len(f"## [{version_no}]")
+        end = (
+            data.index("## [", start + 1)
+            if "## [" in data[start + 1 :]
+            else data.index("[", start + 1)
+            if "[" in data[start + 1 :]
+            else len(data)
+        )
+        release_notes = data[start:end].strip()
+
+    print(release_notes)
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    sys.exit(main(*sys.argv))

--- a/.github/scripts/update_changelog.py
+++ b/.github/scripts/update_changelog.py
@@ -1,0 +1,61 @@
+"""Update the changelog for a new release.
+
+This script drafts a new release in the CHANGELOG.md file by adding a new section
+for the specified version and updating the links accordingly.
+
+This script expects the changelog format to be based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+"""
+
+import sys
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def main(*args) -> int:
+    """Main function to update the changelog."""
+    version_no = None
+    changelog_file_path = "CHANGELOG.md"
+    unreleased_section = "## [Unreleased]"
+    unreleased_url = (
+        "https://github.com/yashovardhan99/bulkinvoicer/compare/v{version}...HEAD"
+    )
+    unreleased_url_label = "[unreleased]: "
+
+    if len(args) > 1:
+        for arg in args[1:]:
+            if arg.endswith(".md"):
+                file = arg
+            elif arg.startswith("v"):
+                version_no = arg[1:]
+                break
+    logger.info("Updating changelog for version number:", version_no)
+
+    if not version_no:
+        raise ValueError("Version number must be specified in the format 'v<version>'")
+
+    with open(changelog_file_path, mode="r+") as file:
+        # Add new section for the version
+        data = file.read()
+        start = data.index(unreleased_section) + len(unreleased_section)
+        file.seek(start)
+        file.write(f"\n\n## [{version_no}]")
+        file.write(data[start:])
+        file.truncate()
+
+        # Add a link for the new version and update the unreleased link
+        file.seek(0)
+        data = file.read()
+        start = data.index(unreleased_url_label) + len(unreleased_url_label)
+        file.seek(start)
+        file.write(unreleased_url.format(version=version_no))
+
+        file.write(f"\n[v{version_no}]: ")
+        file.write(data[start:].replace("...HEAD", f"...v{version_no}"))
+        file.truncate()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(*sys.argv))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
         description: "Branch to create the release from"
         required: true
         default: "main"
+  push:
 jobs:
   prepare-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ on:
         description: "Branch to create the release from"
         required: true
         default: "main"
-  push:
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
@@ -54,7 +53,7 @@ jobs:
       - name: Create Tag
         run: |
           CHANGES=$(python .github/scripts/get_release_notes.py $TAG)
-          git tag -a $TAG -m "$TAG" -m $CHANGES
+          git tag -a $TAG -m "$TAG" -m "$CHANGES"
           git push origin $TAG
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
         required: true
         default: "main"
 jobs:
-  prepare-release:
+  tag-and-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -43,7 +43,7 @@ jobs:
         run: |
           python .github/scripts/update_changelog.py ${{ github.event.inputs.version }}
           git add CHANGELOG.md
-          git commit -m "chore: update changelog for release $TAG"
+          git commit -m "Update changelog for release $TAG"
           git push origin $BRANCH
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -53,8 +53,15 @@ jobs:
       - name: Create Tag
         run: |
           CHANGES=$(python .github/scripts/get_release_notes.py $TAG)
-          git tag -a $TAG -m "$TAG" -m "$CHANGES"
+          git tag -a $TAG -m "$TAG" -m "$CHANGES" --cleanup=whitespace
           git push origin $TAG
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.version }}
+        
+      - name: Create Release
+        run: |
+          gh release create $TAG --notes-from-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.event.inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+# Release Workflow
+# This workflow is used to create a release by updating the changelog,
+# tagging the release, and publishing it to PyPI.
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag for the release (e.g., v1.0.0)"
+        required: true
+      branch:
+        description: "Branch to create the release from"
+        required: true
+        default: "main"
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Log Inputs
+        run: |
+          echo "Version: ${{ github.event.inputs.version }}"
+          echo "Branch: ${{ github.event.inputs.branch }}"
+
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Set up Git
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Update Changelog
+        run: |
+          python .github/scripts/update_changelog.py ${{ github.event.inputs.version }}
+          git add CHANGELOG.md
+          git commit -m "chore: update changelog for release $TAG"
+          git push origin $BRANCH
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.version }}
+          BRANCH: ${{ github.event.inputs.branch }}
+
+      - name: Create Tag
+        run: |
+          CHANGES=$(python .github/scripts/get_release_notes.py $TAG)
+          git tag -a $TAG -m "$TAG" -m $CHANGES
+          git push origin $TAG
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0a0]
+
 ### Added
 
 - Start Changelog file for easy tracking.
@@ -25,5 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sample files and configuration.
 - README and other related files.
 
-[unreleased]: https://github.com/yashovardhan99/bulkinvoicer/compare/v0.1.0.dev1...HEAD
+[unreleased]: https://github.com/yashovardhan99/bulkinvoicer/compare/v0.1.0a0...HEAD
+[v0.1.0a0]: https://github.com/yashovardhan99/bulkinvoicer/compare/v0.1.0.dev1...v0.1.0a0
 [0.1.0.dev1]: https://github.com/yashovardhan99/bulkinvoicer/commits/v0.1.0.dev1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0a0]
-
 ### Added
 
 - Start Changelog file for easy tracking.
@@ -27,6 +25,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sample files and configuration.
 - README and other related files.
 
-[unreleased]: https://github.com/yashovardhan99/bulkinvoicer/compare/v0.1.0a0...HEAD
-[v0.1.0a0]: https://github.com/yashovardhan99/bulkinvoicer/compare/v0.1.0.dev1...v0.1.0a0
+[unreleased]: https://github.com/yashovardhan99/bulkinvoicer/compare/v0.1.0.dev1...HEAD
 [0.1.0.dev1]: https://github.com/yashovardhan99/bulkinvoicer/commits/v0.1.0.dev1


### PR DESCRIPTION
Adds workflow for automatically creating a tag, updating changelogs and publishing a release on GitHub.
This will work along with the existing publish workflow to finally publish the release to PyPi and GitHub.